### PR TITLE
Skip after prepare hook

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -29,7 +29,9 @@ module.exports = function($logger, $projectData, hookArgs) {
     var platform = hookArgs.platform.toLowerCase(),
         fabricJSON = path.join($projectData.projectDir, 'fabric.json');
     return new Promise(function(resolve, reject) {
-        if (fs.existsSync(fabricJSON)) {
+        var isNativeProjectPrepared = !hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare;
+        var hasFabricJSONFile = fs.existsSync(fabricJSON);
+        if (hasFabricJSONFile && isNativeProjectPrepared) {
             try {
                 var fabricData = require(fabricJSON),
                     apiKey = fabricData.apiKey,
@@ -123,9 +125,12 @@ module.exports = function($logger, $projectData, hookArgs) {
                 $logger.error('Unknown error during prepare fabric', e);
                 reject();
             }
-        } else {
+        } else if (!hasFabricJSONFile) {
             $logger.error('Please create a fabric.json file in the root!');
             reject();
+        } else {
+            $logger.trace("Native project not prepared.");
+            resolve();
         }
     });
 };


### PR DESCRIPTION
After this change https://github.com/NativeScript/nativescript-cli/pull/2983 the NativeScript CLI can prepare only the JaveScript part of the project.
This is required for cloud builds in the NativeScript Sidekick -> https://www.nativescript.org/nativescript-sidekick.
This means that the native files required in the after prepare hook can be missing.
To check if the native project is prepared we should check the value of nativePrepare.skipNativePrepare which is passed in the hookArgs.

ping @hypery2k 