### PR TITLE
Remove angular export from index.d.ts.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,3 @@ export * from './fabric.android';
 
 // Export any shared classes, constants, etc.
 export * from './fabric.common';
-
-// export Angular Module
-export * from './app/app.module';


### PR DESCRIPTION
On this library version, i have some problems with import Fabric from nativescript-fabric. On my library read , i found that piece of code, indicates if I have the Nativescript pure, load Angular extension and crash. 
Removing that code block, fix that issue.