### PR TITLE
Fix a crash on Android due to missing metadata

### DIFF
--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -26,7 +26,7 @@ https://docs.nativescript.org/ui/components.
     -->
     <StackLayout class="p-20">
         <Label text="Tap the button" class="h1 text-center"/>
-        <Button text="TAP" tap="{{ onTap }}" automationText="tapButton" class="btn btn-primary btn-active"/>
+        <Button text="TAP to crash :)" tap="{{ onTap }}" automationText="tapButton" class="btn btn-primary btn-active"/>
         <Label text="{{ message }}" class="h2 text-center" textWrap="true"/>
         <Label text="app URL:" class="h1 text-center"/>
         <Label text="{{ appURL }}" automationText="appURL" class="h2 text-center" textWrap="true"/>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'data/observable';
 import { Fabric } from 'nativescript-fabric';
 
+declare const java: any;
+
 export class HelloWorldModel extends Observable {
 
   private _counter: number;
@@ -28,6 +30,7 @@ export class HelloWorldModel extends Observable {
   public onTap() {
     this._counter--;
     this.updateMessage();
+    throw new java.lang.RuntimeException("This is a crash!");
   }
 
   private updateMessage() {

--- a/src/lib/postinstall.js
+++ b/src/lib/postinstall.js
@@ -3231,26 +3231,48 @@ module.exports = function($logger, $projectData, hookArgs) {
     }
   }
 
-  if (platform === 'android') {
+  function updateGradleAppScript(file) {
+    let appBuildGradleContent = fs.readFileSync(file).toString();
+    if (appBuildGradleContent.indexOf("buildMetadata.finalizedBy(copyMetadata)") === -1) {
+      appBuildGradleContent = appBuildGradleContent.replace("ensureMetadataOutDir.finalizedBy(buildMetadata)", "ensureMetadataOutDir.finalizedBy(buildMetadata)\\n\\t\\tbuildMetadata.finalizedBy(copyMetadata)");
+      appBuildGradleContent += \`
+task copyMetadata {
+  doLast {
+    copy {
+        from "$projectDir/src/main/assets/metadata"
+        def toDir = project.hasProperty("release") ? "release" : "debug";
+        if (new File("$projectDir/build/intermediates/assets").listFiles() != null) {
+          toDir = new File("$projectDir/build/intermediates/assets").listFiles()[0].name
+          if (toDir != 'debug' && toDir != 'release') {
+            toDir += "/release"
+          }
+        }
+        into "$projectDir/build/intermediates/assets/" + toDir + "/metadata"
+    }
+  }
+}\`;
+      fs.writeFileSync(file, appBuildGradleContent);
+    }
+  }
 
+  if (platform === 'android') {
       var apiKey = "${config.api_key}";
       var apiSecret = "${config.api_secret}";
       var androidPlatformDir = path.join(__dirname, "..", "..", 'platforms', 'android');
       var androidAppPlatformDir = path.join(__dirname, "..", "..", 'platforms', 'android', 'app');
       var gradleScript = path.join(androidPlatformDir, 'build.gradle');
       var gradleAppScript = path.join(androidAppPlatformDir, 'build.gradle');
-      var settingsJson = path.join(__dirname, "..", "..", "platforms", "android", "src", "main", "res", "fabric.properties");
 
       updateGradleScript(gradleScript);
+      updateGradleAppScript(gradleAppScript);
 
-      settingsJson = path.join(__dirname, "..", "..", "platforms", "android", "app", "src", "main", "res", "fabric.properties");
+      var settingsJson = path.join(__dirname, "..", "..", "platforms", "android", "app", "src", "main", "res", "fabric.properties");
 
       var propertiesContent = '# Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public\\n';
       propertiesContent+='apiKey = ' + apiKey + '\\n';
       propertiesContent+='apiSecret = ' + apiSecret + '\\n';
       fs.writeFileSync(settingsJson, propertiesContent);
       $logger.trace('Written fabric.properties');
-
   }
 };
 `;

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -18,3 +18,4 @@ dependencies {
   }
 }
 
+apply plugin: "io.fabric"


### PR DESCRIPTION
This works for me on this branch. It's a [similar fix I had to apply to the Firebase plugin](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/pull/549#issuecomment-384046737) to get Crashlytics working.

Fixes #114